### PR TITLE
Fix categories, add packages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+GITHUB_TOKEN=

--- a/database/json/packages.json
+++ b/database/json/packages.json
@@ -1005,7 +1005,7 @@
     {
         "name": "Blueprint",
         "description": "A code generation tool for developers.",
-        "category": "CMS & Admin Panels",
+        "category": "Debugging & Dev Tools",
         "github": "https://github.com/laravel-shift/blueprint",
         "author": "laravel-shift",
         "composer": "laravel-shift/blueprint",
@@ -3076,7 +3076,7 @@
     {
         "name": "Mix",
         "description": "The power of Webpack, distilled for the rest of us.",
-        "category": "Debugging & Dev Tools",
+        "category": "Code Architecture",
         "github": "https://github.com/laravel-mix/laravel-mix",
         "author": "laravel-mix",
         "composer": null,
@@ -3200,7 +3200,7 @@
     {
         "name": "Laravel Server Side Rendering",
         "description": "Server-side rendering JavaScript in your application.",
-        "category": "Debugging & Dev Tools",
+        "category": "Dev Ops",
         "github": "https://github.com/spatie/laravel-server-side-rendering",
         "author": "spatie",
         "composer": "spatie/laravel-server-side-rendering",
@@ -3302,7 +3302,7 @@
     {
         "name": "Laravel Swoole",
         "description": "High-performance HTTP server based on Swoole. Speed up your applications.",
-        "category": "Debugging & Dev Tools",
+        "category": "Dev Ops",
         "github": "https://github.com/swooletw/laravel-swoole",
         "author": "swooletw",
         "composer": "swooletw/laravel-swoole",
@@ -4888,7 +4888,7 @@
     {
         "name": "Smart",
         "description": "Easy image manipulation and file downloads.",
-        "category": "UI & Blade Components",
+        "category": "File Management",
         "github": "https://github.com/dietercoopman/smart",
         "author": "dietercoopman",
         "composer": "dietercoopman/smart",
@@ -4932,7 +4932,7 @@
     {
         "name": "Laravel Markdown",
         "description": "A CommonMark wrapper.",
-        "category": "UI & Blade Components",
+        "category": "Utilities & Helpers",
         "github": "https://github.com/GrahamCampbell/Laravel-Markdown",
         "author": "graham-campbell",
         "composer": "graham-campbell/markdown",
@@ -5730,7 +5730,7 @@
     {
         "name": "Transporter",
         "description": "A futuristic way to send API requests in PHP. This is an OOP approach to handling API requests.",
-        "category": "Utilities & Helpers",
+        "category": "API",
         "github": "https://github.com/JustSteveKing/laravel-transporter",
         "author": "juststeveking",
         "composer": "juststeveking/laravel-transporter",
@@ -5788,7 +5788,7 @@
     {
         "name": "Octane",
         "description": "Supercharge your application performance.",
-        "category": "Utilities & Helpers",
+        "category": "Dev Ops",
         "github": "https://github.com/laravel/octane",
         "author": "laravel",
         "composer": "laravel/octane",
@@ -7244,7 +7244,7 @@
     {
         "name": "Ziggy",
         "description": "Use your named routes in JavaScript.",
-        "category": "Debugging & Dev Tools",
+        "category": "Code Architecture",
         "github": "https://github.com/tighten/ziggy",
         "author": "tightenco",
         "composer": "tightenco/ziggy",
@@ -7285,7 +7285,7 @@
         "package_type": "laravel-package",
         "name": "Laravel Wave",
         "description": "Real-time broadcasting with SSE (native HTTP) without any Websockets setup.",
-        "category": "Utilities & Helpers",
+        "category": "Notifications",
         "github": "https://github.com/qruto/laravel-wave",
         "author": "qruto",
         "composer": "qruto/laravel-wave",
@@ -7694,7 +7694,9 @@
         "composer": "stechstudio/laravel-zipstream",
         "npm": null,
         "stars": 295,
-        "keywords": [],
+        "keywords": [
+            "archive"
+        ],
         "first_release_at": "2019-04-12T18:20:20+00:00",
         "latest_release_at": "2023-02-23T20:57:15+00:00",
         "laravel_dependency_versions": [
@@ -8006,5 +8008,46 @@
         "paid_integration": false,
         "updated_at": "2023-06-06T20:44:32.351Z",
         "created_at": "2023-06-06T20:44:32.351Z"
+    },
+    {
+        "package_type": "php-package",
+        "name": "PHP Standard Library",
+        "description": "Modern, consistent, centralized, well-typed set of APIs for PHP developers.",
+        "category": "Utilities & Helpers",
+        "github": "https://github.com/azjezz/psl",
+        "author": "azjezz",
+        "composer": "azjezz/psl",
+        "npm": null,
+        "stars": 1035,
+        "keywords": [],
+        "first_release_at": "2019-12-24T14:01:05+00:00",
+        "latest_release_at": "2023-05-18T10:12:44+00:00",
+        "laravel_dependency_versions": [],
+        "paid_integration": false,
+        "updated_at": "2023-06-06T21:13:38.240Z",
+        "created_at": "2023-06-06T21:13:38.241Z"
+    },
+    {
+        "package_type": "laravel-package",
+        "name": "Turnstile",
+        "description": "Integration with Cloudflare Turnstile.",
+        "category": "Security",
+        "github": "https://github.com/ryangjchandler/laravel-cloudflare-turnstile",
+        "author": "ryangjchandler",
+        "composer": "ryangjchandler/laravel-cloudflare-turnstile",
+        "npm": null,
+        "stars": 83,
+        "keywords": [
+            "cloudflare",
+            "captcha"
+        ],
+        "first_release_at": "2022-09-30T10:10:44+00:00",
+        "latest_release_at": "2023-04-14T10:20:16+00:00",
+        "laravel_dependency_versions": [
+            "^10.0"
+        ],
+        "paid_integration": false,
+        "updated_at": "2023-06-06T21:14:43.192Z",
+        "created_at": "2023-06-06T21:14:43.192Z"
     }
 ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,7 +85,7 @@ devDependencies:
     version: 10.1.2(vue@3.3.4)
   '@vueuse/nuxt':
     specifier: ^10.1.2
-    version: 10.1.2(nuxt@3.5.2)(vue@3.3.4)
+    version: 10.1.2(nuxt@3.5.3)(vue@3.3.4)
   autoprefixer:
     specifier: ^10.4.14
     version: 10.4.14(postcss@8.4.24)
@@ -144,8 +144,8 @@ devDependencies:
     specifier: ^6.1.0
     version: 6.1.0
   nuxt:
-    specifier: ^3.5.2
-    version: 3.5.2(@types/node@20.2.5)(eslint@8.42.0)(stylus@0.59.0)(typescript@5.1.3)
+    specifier: ^3.5.3
+    version: 3.5.3(@types/node@20.2.5)(eslint@8.42.0)(stylus@0.59.0)(typescript@5.1.3)
   nuxt-gtag:
     specifier: ^0.5.7
     version: 0.5.7
@@ -1087,6 +1087,32 @@ packages:
       - supports-color
     dev: true
 
+  /@nuxt/kit@3.5.3:
+    resolution: {integrity: sha512-QzoOGqa1zjKQfg7Y50TrrFAL9DhtIpYYs10gihcM1ISPrn9ROht+VEjqsaMvT+L8JuQbNf8wDYl8qzsdWGU29Q==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+    dependencies:
+      '@nuxt/schema': 3.5.3
+      c12: 1.4.1
+      consola: 3.1.0
+      defu: 6.1.2
+      globby: 13.1.4
+      hash-sum: 2.0.0
+      ignore: 5.2.4
+      jiti: 1.18.2
+      knitwork: 1.0.0
+      mlly: 1.3.0
+      pathe: 1.1.1
+      pkg-types: 1.0.3
+      scule: 1.0.0
+      semver: 7.5.1
+      unctx: 2.3.1
+      unimport: 3.0.7(rollup@3.23.0)
+      untyped: 1.3.2
+    transitivePeerDependencies:
+      - rollup
+      - supports-color
+    dev: true
+
   /@nuxt/schema@3.5.0:
     resolution: {integrity: sha512-zz7S5RTCTGSCAyfNxO0R+TYvgk7WQdHUWJiAiTFQ+iFtqQkb/re1I86Ba9VKTJjZmm3fUI5kT5Y62emJcOLlXw==}
     engines: {node: ^14.18.0 || >=16.10.0}
@@ -1141,11 +1167,29 @@ packages:
       - supports-color
     dev: true
 
+  /@nuxt/schema@3.5.3:
+    resolution: {integrity: sha512-Tnon4mYfJZmsCtx4NZ9A+qjwo4DcZ6tERpEhYBY81PX7AiJ+hFPBFR1qR32Tff66/qJjZg5UXj6H9AdzwEYr2w==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+    dependencies:
+      defu: 6.1.2
+      hookable: 5.5.3
+      pathe: 1.1.1
+      pkg-types: 1.0.3
+      postcss-import-resolver: 2.0.0
+      std-env: 3.3.3
+      ufo: 1.1.2
+      unimport: 3.0.7(rollup@3.23.0)
+      untyped: 1.3.2
+    transitivePeerDependencies:
+      - rollup
+      - supports-color
+    dev: true
+
   /@nuxt/telemetry@2.2.0:
     resolution: {integrity: sha512-Z2UmPkBy5WjxvHKuUcl1X6vKWnIyWSP+9UGde1F+MzzZxYgAQybFud1uL2B3KCowxZdoqT1hd2WklV7EtyCwrQ==}
     hasBin: true
     dependencies:
-      '@nuxt/kit': 3.5.2
+      '@nuxt/kit': 3.5.3
       chalk: 5.2.0
       ci-info: 3.8.0
       consola: 3.1.0
@@ -1174,13 +1218,13 @@ packages:
     resolution: {integrity: sha512-PjVETP7+iZXAs5Q8O4ivl4t6qjWZMZqwiTVogUXHoHGZZcw7GZW3u3tzfYfE1HbzyYJfr236IXqQ02MeR8Fz2w==}
     dev: true
 
-  /@nuxt/vite-builder@3.5.2(@types/node@20.2.5)(eslint@8.42.0)(stylus@0.59.0)(typescript@5.1.3)(vue@3.3.4):
-    resolution: {integrity: sha512-w7ajMtMGKq/PE+dAcfuHio3qgE9ow51LZtNLJlmao3PXHzcpFBJLuuhlOumfwDX1ubpwDhoR8YcOsGwY9JWHqQ==}
+  /@nuxt/vite-builder@3.5.3(@types/node@20.2.5)(eslint@8.42.0)(stylus@0.59.0)(typescript@5.1.3)(vue@3.3.4):
+    resolution: {integrity: sha512-7zEKpGh3iWGRDwbWUa8eRxdLMxZtPzetelmdmXPjtYKGwUebZOcBhpeJ+VgJKOIf4OEj9E7BZS+it/Ji9UG9qw==}
     engines: {node: ^14.18.0 || >=16.10.0}
     peerDependencies:
       vue: ^3.3.4
     dependencies:
-      '@nuxt/kit': 3.5.2
+      '@nuxt/kit': 3.5.3
       '@rollup/plugin-replace': 5.0.2(rollup@3.23.0)
       '@vitejs/plugin-vue': 4.2.3(vite@4.3.9)(vue@3.3.4)
       '@vitejs/plugin-vue-jsx': 3.0.1(vite@4.3.9)(vue@3.3.4)
@@ -1200,7 +1244,7 @@ packages:
       magic-string: 0.30.0
       mlly: 1.3.0
       ohash: 1.1.2
-      pathe: 1.1.0
+      pathe: 1.1.1
       perfect-debounce: 1.0.0
       pkg-types: 1.0.3
       postcss: 8.4.24
@@ -1212,7 +1256,7 @@ packages:
       ufo: 1.1.2
       unplugin: 1.3.1
       vite: 4.3.9(@types/node@20.2.5)(stylus@0.59.0)
-      vite-node: 0.31.1(@types/node@20.2.5)(stylus@0.59.0)
+      vite-node: 0.31.4(@types/node@20.2.5)(stylus@0.59.0)
       vite-plugin-checker: 0.6.0(eslint@8.42.0)(typescript@5.1.3)(vite@4.3.9)
       vue: 3.3.4
       vue-bundle-renderer: 1.0.3
@@ -2097,7 +2141,7 @@ packages:
     resolution: {integrity: sha512-3mc5BqN9aU2SqBeBuWE7ne4OtXHoHKggNgxZR2K+zIW4YLsy6xoZ4/9vErQs6tvoKDX6QAqm3lvsrv0mczAwIQ==}
     dev: true
 
-  /@vueuse/nuxt@10.1.2(nuxt@3.5.2)(vue@3.3.4):
+  /@vueuse/nuxt@10.1.2(nuxt@3.5.3)(vue@3.3.4):
     resolution: {integrity: sha512-X9o5WCmNs1+6XztP1Uh9+H7/jGeIjwSRNQdwCWRKCDkxPlbgi9iLnDRYnKDY++JPY3nbB6jTDOVgZDrpaAU5kg==}
     peerDependencies:
       nuxt: ^3.0.0
@@ -2106,7 +2150,7 @@ packages:
       '@vueuse/core': 10.1.2(vue@3.3.4)
       '@vueuse/metadata': 10.1.2
       local-pkg: 0.4.3
-      nuxt: 3.5.2(@types/node@20.2.5)(eslint@8.42.0)(stylus@0.59.0)(typescript@5.1.3)
+      nuxt: 3.5.3(@types/node@20.2.5)(eslint@8.42.0)(stylus@0.59.0)(typescript@5.1.3)
       vue-demi: 0.14.5(vue@3.3.4)
     transitivePeerDependencies:
       - '@vue/composition-api'
@@ -2504,9 +2548,9 @@ packages:
       dotenv: 16.1.4
       giget: 1.1.2
       jiti: 1.18.2
-      mlly: 1.2.1
+      mlly: 1.3.0
       ohash: 1.1.2
-      pathe: 1.1.0
+      pathe: 1.1.1
       perfect-debounce: 0.1.3
       pkg-types: 1.0.3
       rc9: 2.1.0
@@ -3134,7 +3178,7 @@ packages:
     dev: true
 
   /ee-first@1.1.1:
-    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+    resolution: {integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=}
     dev: true
 
   /electron-to-chromium@1.4.402:
@@ -3635,7 +3679,7 @@ packages:
     dependencies:
       enhanced-resolve: 5.14.0
       mlly: 1.3.0
-      pathe: 1.1.0
+      pathe: 1.1.1
       ufo: 1.1.2
     dev: true
 
@@ -3919,7 +3963,7 @@ packages:
       https-proxy-agent: 5.0.1
       mri: 1.2.0
       node-fetch-native: 1.1.1
-      pathe: 1.1.0
+      pathe: 1.1.1
       tar: 6.1.15
     transitivePeerDependencies:
       - supports-color
@@ -5102,7 +5146,7 @@ packages:
     resolution: {integrity: sha512-HT5mcgIQKkOrZecOjOX3DJorTikWXwsBfpcr/MGBkhfWcjiqvnaL/9ppxvIUXfjT6xt4DVIAsN9fMUz1ev4bIw==}
     dependencies:
       acorn: 8.8.2
-      pathe: 1.1.0
+      pathe: 1.1.1
       pkg-types: 1.0.3
       ufo: 1.1.2
     dev: true
@@ -5217,7 +5261,7 @@ packages:
       ofetch: 1.0.1
       ohash: 1.1.2
       openapi-typescript: 6.2.4
-      pathe: 1.1.0
+      pathe: 1.1.1
       perfect-debounce: 1.0.0
       pkg-types: 1.0.3
       pretty-bytes: 6.1.0
@@ -5386,8 +5430,8 @@ packages:
       boolbase: 1.0.0
     dev: true
 
-  /nuxi@3.5.2:
-    resolution: {integrity: sha512-6zkgQpMbv74vITFiu9TGe8UXsBOCxEy3Nw1/wYjRBH0p1gGLl0/rxubAeSpXw3NHQzRHTt75fYgWEGOfzPWOXQ==}
+  /nuxi@3.5.3:
+    resolution: {integrity: sha512-H0/Nj0ulUN8PrSvr6H433Awt4hNT5uaN57041QfknYVXlUce7yEbl/NcpNtnneAHYn2hMUZL9/nJCVkZ1xTvHA==}
     engines: {node: ^14.18.0 || >=16.10.0}
     hasBin: true
     optionalDependencies:
@@ -5422,8 +5466,8 @@ packages:
       - supports-color
     dev: true
 
-  /nuxt@3.5.2(@types/node@20.2.5)(eslint@8.42.0)(stylus@0.59.0)(typescript@5.1.3):
-    resolution: {integrity: sha512-PVA+1d0UBujODogxhnfbolYFOawAf2paOVlARxJdm1npVQBPz9Ns8tKpWglbZhwRdXpj1jDE9Dl+Ke3pl59dZw==}
+  /nuxt@3.5.3(@types/node@20.2.5)(eslint@8.42.0)(stylus@0.59.0)(typescript@5.1.3):
+    resolution: {integrity: sha512-fG39BZ5N5ATtmx2vuxN8APQPSlSsCDpfkJ0k581gMc7eFztqrBzPncZX5w3RQLW7AiGBE2yYEfqiwC6AVODBBg==}
     engines: {node: ^14.18.0 || >=16.10.0}
     hasBin: true
     peerDependencies:
@@ -5434,11 +5478,11 @@ packages:
         optional: true
     dependencies:
       '@nuxt/devalue': 2.0.2
-      '@nuxt/kit': 3.5.2
-      '@nuxt/schema': 3.5.2
+      '@nuxt/kit': 3.5.3
+      '@nuxt/schema': 3.5.3
       '@nuxt/telemetry': 2.2.0
       '@nuxt/ui-templates': 1.1.1
-      '@nuxt/vite-builder': 3.5.2(@types/node@20.2.5)(eslint@8.42.0)(stylus@0.59.0)(typescript@5.1.3)(vue@3.3.4)
+      '@nuxt/vite-builder': 3.5.3(@types/node@20.2.5)(eslint@8.42.0)(stylus@0.59.0)(typescript@5.1.3)(vue@3.3.4)
       '@types/node': 20.2.5
       '@unhead/ssr': 1.1.27
       '@unhead/vue': 1.1.27(vue@3.3.4)
@@ -5462,11 +5506,11 @@ packages:
       magic-string: 0.30.0
       mlly: 1.3.0
       nitropack: 2.4.1
-      nuxi: 3.5.2
+      nuxi: 3.5.3
       nypm: 0.2.0
       ofetch: 1.0.1
       ohash: 1.1.2
-      pathe: 1.1.0
+      pathe: 1.1.1
       perfect-debounce: 1.0.0
       prompts: 2.4.2
       scule: 1.0.0
@@ -7248,7 +7292,7 @@ packages:
       defu: 6.1.2
       mime: 3.0.0
       node-fetch-native: 1.1.1
-      pathe: 1.1.0
+      pathe: 1.1.1
     dev: true
 
   /unhead@1.1.27:
@@ -7351,7 +7395,7 @@ packages:
       json5: 2.2.3
       local-pkg: 0.4.3
       mlly: 1.3.0
-      pathe: 1.1.0
+      pathe: 1.1.1
       scule: 1.0.0
       unplugin: 1.3.1
       vue-router: 4.2.2(vue@3.3.4)
@@ -7460,15 +7504,15 @@ packages:
       spdx-expression-parse: 3.0.1
     dev: true
 
-  /vite-node@0.31.1(@types/node@20.2.5)(stylus@0.59.0):
-    resolution: {integrity: sha512-BajE/IsNQ6JyizPzu9zRgHrBwczkAs0erQf/JRpgTIESpKvNj9/Gd0vxX905klLkb0I0SJVCKbdrl5c6FnqYKA==}
+  /vite-node@0.31.4(@types/node@20.2.5)(stylus@0.59.0):
+    resolution: {integrity: sha512-uzL377GjJtTbuc5KQxVbDu2xfU/x0wVjUtXQR2ihS21q/NK6ROr4oG0rsSkBBddZUVCwzfx22in76/0ZZHXgkQ==}
     engines: {node: '>=v14.18.0'}
     hasBin: true
     dependencies:
       cac: 6.7.14
       debug: 4.3.4
       mlly: 1.3.0
-      pathe: 1.1.0
+      pathe: 1.1.1
       picocolors: 1.0.0
       vite: 4.3.9(@types/node@20.2.5)(stylus@0.59.0)
     transitivePeerDependencies:


### PR DESCRIPTION
This pull request:
- Fixes a few categories
- Adds two new packages
- Adds a `.env.example`

The packages added are:
- https://github.com/azjezz/psl
- https://github.com/ryangjchandler/laravel-cloudflare-turnstile.

The category changes are as follow:
- Blueprint: `CMS & Admin Panels` -> `Debugging & Dev Tools` (it's a CLI for scaffolding stuff)
- Laravel Mix: `Debugging & Dev Tools` -> `Code Architecture`
- Laravel SSR: `Debugging & Dev Tools` -> `Dev Ops`
- Swoole: `Debugging & Dev Tools` -> `Dev Ops`
- Smart: `UI & Blade Components` -> `File Management`
- Laravel Markdown: `UI & Blade Components` -> `Utilities & Helpers`
- Transporter: `Utilities & Helpers` -> `API` (it was fine, but since Saloon is in API, Transporter belongs there too)
- Octane: `Utilities & Helpers` -> `Dev Ops`
- Ziggy: `Debugging & Dev Tools` -> `Code Architecture` (could maybe be in utilities & helpers)
- Laravel Wave: `Utilities & Helpers` -> `Notifications` (since Echo is there too)