### PR TITLE
Refactor buttons and improve auto scroll on pagination events

### DIFF
--- a/components/package/list.vue
+++ b/components/package/list.vue
@@ -366,8 +366,8 @@ const categoriesForSelectboxWithAll = [
                 <!-- New Since Last Visit Button -->
                 <ui-new-packages-button
                     v-if="newPackagesSinceLastVisit.length"
-                    :newPackagesCount="newPackagesSinceLastVisit.length"
-                    :isActive="showNewPackagesSinceLastVisit"
+                    :new-packages-count="newPackagesSinceLastVisit.length"
+                    :is-active="showNewPackagesSinceLastVisit"
                     @toggle="showNewPackagesSinceLastVisit = !showNewPackagesSinceLastVisit"
                     />
             </div>

--- a/components/package/list.vue
+++ b/components/package/list.vue
@@ -365,43 +365,12 @@ const categoriesForSelectboxWithAll = [
                     </div>
                 </transition>
                 <!-- New Since Last Visit Button -->
-                <ui-tooltip
+                <ui-new-packages-button
                     v-if="newPackagesSinceLastVisit.length"
-                    :content="newPackagesSinceLastVisit.length + ' New packages were added since your last visit !'"
-                    theme="emerald"
-                    @click.stop.prevent="showNewPackagesSinceLastVisit = !showNewPackagesSinceLastVisit"
-                    >
-                    <div
-
-                        class="py-1.5 px-4 select-none
-                        rounded-full cursor-pointer
-                        transition-all duration-300
-                        flex gap-2 items-center
-                        font-medium
-                        hover:brightness-105
-                        "
-                        :class="{
-                            'bg-slate-300/50 dark:bg-slate-700/50 text-slate-600 dark:text-slate-400': !showNewPackagesSinceLastVisit,
-                            'bg-teal-200/70 text-teal-600 dark:text-teal-500 dark:bg-teal-500/20': showNewPackagesSinceLastVisit,
-                        }"
-                        >
-                        <span class="relative flex h-2.5 w-2.5">
-                            <span
-                                class="animate-ping absolute inline-flex h-full w-full rounded-full bg-teal-400"
-                                :class="{
-                                    'opacity-75': !showNewPackagesSinceLastVisit,
-                                    'opacity-0': showNewPackagesSinceLastVisit,
-                                }"
-                                />
-                            <span class="relative inline-flex rounded-full h-2.5 w-2.5 bg-teal-500" />
-                        </span>
-                        <div class="">
-                            {{ newPackagesSinceLastVisit.length }}
-                            <span class="inline">New Item</span>
-                            <span class="inline">{{ newPackagesSinceLastVisit.length > 1 ? 's' : '' }}</span>
-                        </div>
-                    </div>
-                </ui-tooltip>
+                    :newPackagesCount="newPackagesSinceLastVisit.length"
+                    :showNewPackagesSinceLastVisit="showNewPackagesSinceLastVisit"
+                    @toggle="showNewPackagesSinceLastVisit = !showNewPackagesSinceLastVisit"
+                    />
             </div>
             <div
                 class="xl:flex-1

--- a/components/package/list.vue
+++ b/components/package/list.vue
@@ -381,45 +381,10 @@ const categoriesForSelectboxWithAll = [
                 "
                 >
                 <!-- Crown/Official package toggle -->
-                <div class="flex-1 flex justify-start min-[920px]:justify-end w-40">
-                    <div
-                        class="relative rounded-xl cursor-pointer group select-none
-                        transition-all duration-300 ease-out
-                        delay-100
-                        overflow-hidden
-                        w-[12.5rem] sm:w-40 lg:w-11 h-11
-                        flex gap-2 items-center
-                        lg:hover:w-40
-                        "
-                        :class="{
-                            'bg-white/50 dark:bg-[#362B59]/30 dark:hover:bg-[#362B59]/40': showOfficialPackages !== '1',
-                            'lg:w-40 bg-white hover:bg-white/80 dark:bg-indigo-500/20 dark:hover:bg-indigo-500/10': showOfficialPackages === '1',
-                        }"
-                        @click="showOfficialPackages = showOfficialPackages === '1' ? '0' : '1'"
-                        >
-                        <div
-                            class="i-fluent-emoji-crown text-2xl
-                            shrink-0
-                            mb-1 ml-2.5
-                            "
-                            />
-                        <div
-                            class="truncate
-                            leading-5
-                            sm:text-xs
-                            transition duration-300
-                            delay-100
-                            lg:opacity-0
-                            lg:group-hover:opacity-100
-                            "
-                            :class="{
-                                'lg:opacity-100': showOfficialPackages === '1',
-                            }"
-                            >
-                            Official Packages
-                        </div>
-                    </div>
-                </div>
+                <ui-official-package-toggle
+                    :is-active="showOfficialPackages"
+                    @toggle="showOfficialPackages = showOfficialPackages === '1' ? '0' : '1'"
+                    />
                 <!-- Search bar -->
                 <ui-search-input />
                 <!-- Sort -->

--- a/components/package/list.vue
+++ b/components/package/list.vue
@@ -140,10 +140,9 @@ watch(
             results.value = newPackagesSinceLastVisit.value
 
         // if newPage is changed, scroll to #scroll-to-reference element
-        if (newPage !== oldPage) {
+        if (newPage !== oldPage && oldPage !== undefined) {
             nextTick(() => {
-                // If device width is less than 640px (mobile), scroll to #scroll-to-reference element
-                if (process.client && window.innerWidth < 640)
+                if (process.client)
                     document.querySelector('#scroll-to-reference')?.scrollIntoView({ behavior: 'smooth' })
             })
         }

--- a/components/package/list.vue
+++ b/components/package/list.vue
@@ -367,7 +367,7 @@ const categoriesForSelectboxWithAll = [
                 <ui-new-packages-button
                     v-if="newPackagesSinceLastVisit.length"
                     :newPackagesCount="newPackagesSinceLastVisit.length"
-                    :showNewPackagesSinceLastVisit="showNewPackagesSinceLastVisit"
+                    :isActive="showNewPackagesSinceLastVisit"
                     @toggle="showNewPackagesSinceLastVisit = !showNewPackagesSinceLastVisit"
                     />
             </div>

--- a/components/ui/new-packages-button.vue
+++ b/components/ui/new-packages-button.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+defineProps<{
+    newPackagesCount: number,
+    showNewPackagesSinceLastVisit: boolean
+}>()
+
+const $emit = defineEmits<{
+    (e: 'toggle'): void
+}>()
+</script>
+
+<template>
+    <ui-tooltip
+    :content="newPackagesCount + ' New packages were added since your last visit !'"
+    theme="emerald"
+    @click.stop.prevent="$emit('toggle')"
+    >
+        <div
+            class="py-1.5 px-4 select-none
+            rounded-full cursor-pointer
+            transition-all duration-300
+            flex gap-2 items-center
+            font-medium
+            hover:brightness-105
+            "
+            :class="{
+                'bg-slate-300/50 dark:bg-slate-700/50 text-slate-600 dark:text-slate-400': !showNewPackagesSinceLastVisit,
+                'bg-teal-200/70 text-teal-600 dark:text-teal-500 dark:bg-teal-500/20': showNewPackagesSinceLastVisit,
+            }"
+            >
+            <span class="relative flex h-2.5 w-2.5">
+                <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-teal-400" :class="{
+                    'opacity-75': !showNewPackagesSinceLastVisit,
+                    'opacity-0': showNewPackagesSinceLastVisit,
+                }" />
+                <span class="relative inline-flex rounded-full h-2.5 w-2.5 bg-teal-500" />
+            </span>
+            <div class="">
+                {{ newPackagesCount }}
+                <span class="inline">New Item</span>
+                <span class="inline">{{ newPackagesCount > 1 ? 's' : '' }}</span>
+            </div>
+        </div>
+    </ui-tooltip>
+</template>

--- a/components/ui/new-packages-button.vue
+++ b/components/ui/new-packages-button.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 defineProps<{
     newPackagesCount: number,
-    showNewPackagesSinceLastVisit: boolean
+    isActive: boolean
 }>()
 
 const $emit = defineEmits<{
@@ -24,14 +24,14 @@ const $emit = defineEmits<{
             hover:brightness-105
             "
             :class="{
-                'bg-slate-300/50 dark:bg-slate-700/50 text-slate-600 dark:text-slate-400': !showNewPackagesSinceLastVisit,
-                'bg-teal-200/70 text-teal-600 dark:text-teal-500 dark:bg-teal-500/20': showNewPackagesSinceLastVisit,
+                'bg-slate-300/50 dark:bg-slate-700/50 text-slate-600 dark:text-slate-400': !isActive,
+                'bg-teal-200/70 text-teal-600 dark:text-teal-500 dark:bg-teal-500/20': isActive,
             }"
             >
             <span class="relative flex h-2.5 w-2.5">
                 <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-teal-400" :class="{
-                    'opacity-75': !showNewPackagesSinceLastVisit,
-                    'opacity-0': showNewPackagesSinceLastVisit,
+                    'opacity-75': !isActive,
+                    'opacity-0': isActive,
                 }" />
                 <span class="relative inline-flex rounded-full h-2.5 w-2.5 bg-teal-500" />
             </span>

--- a/components/ui/new-packages-button.vue
+++ b/components/ui/new-packages-button.vue
@@ -11,10 +11,10 @@ const $emit = defineEmits<{
 
 <template>
     <ui-tooltip
-    :content="newPackagesCount + ' New packages were added since your last visit !'"
-    theme="emerald"
-    @click.stop.prevent="$emit('toggle')"
-    >
+        :content="newPackagesCount + ' New packages were added since your last visit !'"
+        theme="emerald"
+        @click.stop.prevent="$emit('toggle')"
+        >
         <div
             class="py-1.5 px-4 select-none
             rounded-full cursor-pointer
@@ -29,10 +29,13 @@ const $emit = defineEmits<{
             }"
             >
             <span class="relative flex h-2.5 w-2.5">
-                <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-teal-400" :class="{
-                    'opacity-75': !isActive,
-                    'opacity-0': isActive,
-                }" />
+                <span
+                    class="animate-ping absolute inline-flex h-full w-full rounded-full bg-teal-400"
+                    :class="{
+                        'opacity-75': !isActive,
+                        'opacity-0': isActive,
+                    }"
+                    />
                 <span class="relative inline-flex rounded-full h-2.5 w-2.5 bg-teal-500" />
             </span>
             <div class="">

--- a/components/ui/official-package-toggle.vue
+++ b/components/ui/official-package-toggle.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+defineProps<{
+    isActive: '0' | '1' | ''
+}>()
+
+const $emit = defineEmits<{
+    (e: 'toggle'): void
+}>()
+</script>
+
+<template>
+    <div class="flex-1 flex justify-start min-[920px]:justify-end w-40">
+        <div
+            class="relative rounded-xl cursor-pointer group select-none
+                        transition-all duration-300 ease-out
+                        delay-100
+                        overflow-hidden
+                        w-[12.5rem] sm:w-40 lg:w-11 h-11
+                        flex gap-2 items-center
+                        lg:hover:w-40
+                        "
+            :class="{
+                'bg-white/50 dark:bg-[#362B59]/30 dark:hover:bg-[#362B59]/40': isActive !== '1',
+                'lg:w-40 bg-white hover:bg-white/80 dark:bg-indigo-500/20 dark:hover:bg-indigo-500/10': isActive === '1',
+            }"
+            @click="$emit('toggle')"
+            >
+            <div
+                class="i-fluent-emoji-crown text-2xl
+                            shrink-0
+                            mb-1 ml-2.5
+                            "
+                />
+            <div
+                class="truncate
+                            leading-5
+                            sm:text-xs
+                            transition duration-300
+                            delay-100
+                            lg:opacity-0
+                            lg:group-hover:opacity-100
+                            "
+                :class="{
+                    'lg:opacity-100': isActive === '1',
+                }"
+                >
+                Official Packages
+            </div>
+        </div>
+    </div>
+</template>

--- a/components/ui/official-package-toggle.vue
+++ b/components/ui/official-package-toggle.vue
@@ -12,13 +12,13 @@ const $emit = defineEmits<{
     <div class="flex-1 flex justify-start min-[920px]:justify-end w-40">
         <div
             class="relative rounded-xl cursor-pointer group select-none
-                        transition-all duration-300 ease-out
-                        delay-100
-                        overflow-hidden
-                        w-[12.5rem] sm:w-40 lg:w-11 h-11
-                        flex gap-2 items-center
-                        lg:hover:w-40
-                        "
+            transition-all duration-300 ease-out
+            delay-100
+            overflow-hidden
+            w-[12.5rem] sm:w-40 lg:w-11 h-11
+            flex gap-2 items-center
+            lg:hover:w-40
+            "
             :class="{
                 'bg-white/50 dark:bg-[#362B59]/30 dark:hover:bg-[#362B59]/40': isActive !== '1',
                 'lg:w-40 bg-white hover:bg-white/80 dark:bg-indigo-500/20 dark:hover:bg-indigo-500/10': isActive === '1',
@@ -27,19 +27,19 @@ const $emit = defineEmits<{
             >
             <div
                 class="i-fluent-emoji-crown text-2xl
-                            shrink-0
-                            mb-1 ml-2.5
-                            "
+                shrink-0
+                mb-1 ml-2.5
+                "
                 />
             <div
                 class="truncate
-                            leading-5
-                            sm:text-xs
-                            transition duration-300
-                            delay-100
-                            lg:opacity-0
-                            lg:group-hover:opacity-100
-                            "
+                leading-5
+                sm:text-xs
+                transition duration-300
+                delay-100
+                lg:opacity-0
+                lg:group-hover:opacity-100
+                "
                 :class="{
                     'lg:opacity-100': isActive === '1',
                 }"


### PR DESCRIPTION
1. Created separate component for new packages button and official package toggle button to make the `list.vue` component more maintainable.

2. Currently, disabling autoscroll may be beneficial on external displays. However, on laptops, when you click on pagination links, it does not auto-scroll to the top, requiring manual scrolling, which can be less comfortable. So I suggest to remove the screen width check statement.