### PR TITLE
[FIX] LaraDumps package name and author 

### DIFF
--- a/content/packages/553.yml
+++ b/content/packages/553.yml
@@ -1,9 +1,9 @@
 id: 553
-name: 'Lara Dumps'
+name: 'LaraDumps'
 description: 'A desktop app that provides various debugging tools for your app.'
 category_id: '4'
 github: 'https://github.com/laradumps/laradumps'
-author: laradumps
+author: luanfreitasdev
 composer: laradumps/laradumps
 npm: null
 stars: 632


### PR DESCRIPTION
Hi @HassanZahirnia,

Thank you so much for adding [LaraDumps](https://github.com/laradumps) to [Laravel Package Ocean](https://laravel-package-ocean.com).

This website is a great initiative and it looks wonderful!

This small PR is a correction on the package name and author.

Thanks