### PR TITLE
Add mateffy/laravel-job-progress package

### DIFF
--- a/content/packages/624.yml
+++ b/content/packages/624.yml
@@ -6,7 +6,7 @@ github: 'https://github.com/mateffy/laravel-job-progress'
 author: mateffy
 composer: mateffy/laravel-job-progress
 npm: null
-stars: 19
+stars: 20
 keywords: '["queue", "cancellation", "cache"]'
 first_release_at: '2025-10-10 12:13:57'
 latest_release_at: '2025-11-17 10:08:28'

--- a/content/packages/624.yml
+++ b/content/packages/624.yml
@@ -1,0 +1,17 @@
+id: 624
+name: 'Job Progress For Background Workers'
+description: 'Track and show progress of your background jobs in progress bar UIs and cancel running jobs.'
+category_id: '18'
+github: 'https://github.com/mateffy/laravel-job-progress'
+author: mateffy
+composer: mateffy/laravel-job-progress
+npm: null
+stars: 19
+keywords: '["queue", "cancellation", "cache"]'
+first_release_at: '2025-10-10 12:13:57'
+latest_release_at: '2025-11-17 10:08:28'
+laravel_dependency_versions: '["^11.0|^12.0"]'
+package_type: laravel-package
+paid_integration: 0
+created_at: '2025-11-17T12:34:48+00:00'
+updated_at: '2025-11-17T12:34:48+00:00'


### PR DESCRIPTION
Hello!

I've open-sourced a package we've been using internally for a while. It's a robust way to implement background job progress as well as support cancellation of already running jobs using Laravel's cache system.

The [README](https://github.com/mateffy/laravel-job-progress) is quite detailed on how it works, and I thought it might be a good package to add to the package ocean. :)

Let me know if you need me to change anything!

Thanks for your time!